### PR TITLE
Disable SSRF host validation by default

### DIFF
--- a/patches/main/00-ssrf_check.patch
+++ b/patches/main/00-ssrf_check.patch
@@ -1,0 +1,13 @@
+diff --git a/application/libraries/Caldav_sync.php b/application/libraries/Caldav_sync.php
+index b5eb34c..b9c5e4f 100644
+--- a/application/libraries/Caldav_sync.php
++++ b/application/libraries/Caldav_sync.php
+@@ -29,7 +29,7 @@ use Sabre\VObject\Reader;
+ class Caldav_sync
+ {
+     // Toggle SSRF host validation here (enabled by default).
+-    protected bool $enable_ssrf_check = true;
++    protected bool $enable_ssrf_check = false;
+ 
+     /**
+      * @var EA_Controller|CI_Controller


### PR DESCRIPTION
patch for `application/libraries/Caldav_sync.php`
https://groups.google.com/g/easy-appointments/c/Taz3GUPdz_g
https://forum.yunohost.org/t/easy-appointments-caldav-broken/42375
https://github.com/YunoHost-Apps/easyappointments_ynh/issues/24